### PR TITLE
fix: patch security vuln in jwt-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.15
 
 require (
 	github.com/cyberhorsey/errors v0.0.0-20220929234051-087d6d8bb841
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-playground/locales v0.13.0
 	github.com/go-playground/universal-translator v0.17.0
 	github.com/go-playground/validator/v10 v10.4.0
+	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/google/uuid v1.3.0
 	github.com/labstack/echo/v4 v4.1.15
 	github.com/labstack/gommon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.0 h1:72qIR/m8ybvL8L5TIyfgrigqkrw7kVYAvjEvpT85l70=
 github.com/go-playground/validator/v10 v10.4.0/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
+github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5AU=
+github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/jwt.go
+++ b/jwt.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/cyberhorsey/errors"
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	echo "github.com/labstack/echo/v4"
 )
 

--- a/testutils/http.go
+++ b/testutils/http.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/cyberhorsey/webutils"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
saw a vulnerability from here: https://github.com/advisories/GHSA-w73w-5m7g-f7qc
followed the migration guide here: https://github.com/golang-jwt/jwt/blob/main/MIGRATION_GUIDE.md

we just need to update and test in the downstream project(s), and then run a `go mod tidy` i think